### PR TITLE
Simplify how endpoint is configured and add tests for configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Storage-adapters & utilties for the [OC](https://github.com/opentable/oc) regist
 |--------|-------|-------|
 |S3|[`oc-s3-storage-adapter`](/packages/oc-s3-storage-adapter) | [![npm version](https://badge.fury.io/js/oc-s3-storage-adapter.svg)](http://badge.fury.io/js/oc-s3-storage-adapter) |
 |Google Storage|[`oc-gs-storage-adapter`](/packages/oc-gs-storage-adapter) | [![npm version](https://badge.fury.io/js/oc-gs-storage-adapter.svg)](http://badge.fury.io/js/oc-gs-storage-adapter) |
+|⚠️ WIP! Riak Storage|[`oc-riak-storage-adapter`](/packages/oc-riak-storage-adapter) | [![npm version](https://badge.fury.io/js/oc-riak-storage-adapter.svg)](http://badge.fury.io/js/oc-riak-storage-adapter) |
+
 
 ## Other packages included in this repo
 

--- a/packages/oc-riak-storage-adapter/README.md
+++ b/packages/oc-riak-storage-adapter/README.md
@@ -2,7 +2,7 @@
 
 `⚠️ THIS ADAPTER IS IN ACTIVE DEVELOPMENT, DON'T USE IN PRODUCTION`
 
-RiakCS is a S3 compliant object storage, based on the distributed database Riak by Basho. In other words in case AWS S3 isn't an option RiakCS may be an alternative to run the storage in-house or locally as a developer.
+RiakCS is a S3 compliant object storage, based on the distributed database Riak by Basho. In case AWS S3 isn't an option RiakCS may be an alternative to run the storage in-house or locally as a developer.
 
 ## Installing RiakCS locally
 
@@ -14,13 +14,13 @@ To run and start three buckets, do the following (check https://github.com/ianby
 docker run --env 'RIAK_CS_BUCKETS=foo,bar,baz' --publish '8080:8080' --name 'riak-cs' ianbytchek/riak-cs
 ```
 
-To be able to connect to the S3 storage we need to get the access key and secret key. You will find this in the RiakCS log. To start with, get the docker containerid for the container that we named _riak-cs_:
+This will expose RiakCS on http://localhost:8080/. To be able to interact with the storage you need to get the access key and secret key. You will find this in the RiakCS log. To start with, find the containerid for the container that we named _riak-cs_:
 
 ```
 docker ps
 ```
 
-After RiakCS has started, which may take a minute or two, the keys will show up in the log. 
+After RiakCS has started, which may take a minute or two, the keys will show up top of the log. 
 
 ```
 docker logs <containerid>
@@ -28,7 +28,7 @@ docker logs <containerid>
 
 ## Starting a registry
 
-Make sure you have installed the _oc_ package and the storage adapter.
+Make sure you have installed the _oc_ package and the Riak storage adapter.
 
 ```
 npm install -g oc
@@ -59,7 +59,7 @@ let configuration = {
       componentsDir: 'components',
       signatureVersion: 'v2',       // Use v2 for RiakCS
       sslEnabled: false,
-      path: '//localhost:8080/foo/', 
+      path: 'http://localhost:8080/foo/', 
       s3ForcePathStyle: true,       // Necessary to get the path right
       debug: true,                  // Log what AWS is up to to stdout 
       // Override endpoint, this is passed straight to AWS.Endpoint constructor - https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Endpoint.html 
@@ -87,15 +87,16 @@ node index.js
 
 The registry should be now be exposed on http://localhost:3333/.
 
-To add the registry config run: 
+
+## Publish a component
+
+Go to the directory that contains the component you want to publish. First you have to add the registry by doing: 
 
 ```
 oc registry add http://localhost:3333/
 ``` 
 
-## Publish a component
-
-To publish a component to the registry run
+Finally, to publish the component to the registry run
 
 ```
 oc publish my-component/
@@ -105,7 +106,7 @@ Now the component should be available at http://localhost:3333/my-component.
 
 ## Configuring endpoint
 
-In the example above the full URL is uswed to specify the storage endpoint, ie `http://localhost:8080`. If the protocol is omitted by just specifying `localhost:8080` the configuration will fallback to _https_. 
+In the example above the full URL is used to specify the storage endpoint, ie `http://localhost:8080`. If the protocol is omitted, `localhost:8080`, the configuration will fallback to _https_.
 
 ## Troubleshooting
 

--- a/packages/oc-riak-storage-adapter/README.md
+++ b/packages/oc-riak-storage-adapter/README.md
@@ -63,11 +63,7 @@ let configuration = {
       s3ForcePathStyle: true,       // Necessary to get the path right
       debug: true,                  // Log what AWS is up to to stdout 
       // Override endpoint, this is passed straight to AWS.Endpoint constructor - https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Endpoint.html 
-      endpoint: {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '8080'
-      }  
+      endpoint: 'http://localhost:8080'
     }    
   },
   env: { name: 'production' }
@@ -107,6 +103,9 @@ oc publish my-component/
 
 Now the component should be available at http://localhost:3333/my-component.
 
+## Configuring endpoint
+
+In the example above the full URL is uswed to specify the storage endpoint, ie `http://localhost:8080`. If the protocol is omitted by just specifying `localhost:8080` the configuration will fallback to _https_. 
 
 ## Troubleshooting
 

--- a/packages/oc-s3-storage-adapter/__test__/config.test.js
+++ b/packages/oc-s3-storage-adapter/__test__/config.test.js
@@ -1,0 +1,100 @@
+'use strict';
+jest.dontMock('aws-sdk');
+const s3 = require('../');
+const domain = 'domain.net';
+
+test('Validate endpoint with default settings', () => {
+  const options = {
+    bucket: 'test',
+    region: 'region-test',
+    key: 'test-key',
+    secret: 'test-secret'
+  };
+  const config = new s3(options).getConfig().config;
+  const expectedEndpoint = 's3.' + options.region + '.amazonaws.com';
+  expect(config.endpoint).toEqual(expectedEndpoint);
+});
+
+test('Validate endpoint when configured with just domain name', () => {
+  const options = {
+    bucket: 'test',
+    region: 'region-test',
+    key: 'test-key',
+    secret: 'test-secret',
+    endpoint: domain
+  };
+  const config = new s3(options).getConfig().config;
+  const expectedEndpoint = {
+    host: domain,
+    hostname: domain,
+    href: 'https://' + domain + '/',
+    path: '/',
+    pathname: '/',
+    port: 443,
+    protocol: 'https:'
+  };
+  expect(config.endpoint).toEqual(expectedEndpoint);
+});
+
+test('Validate endpoint to use https by default', () => {
+  const options = {
+    bucket: 'test',
+    region: 'region-test',
+    key: 'test-key',
+    secret: 'test-secret',
+    endpoint: domain
+  };
+  const config = new s3(options).getConfig().config;
+  const expectedEndpoint = {
+    host: domain,
+    hostname: domain,
+    href: 'https://' + domain + '/',
+    path: '/',
+    pathname: '/',
+    port: 443,
+    protocol: 'https:'
+  };
+  expect(config.endpoint).toEqual(expectedEndpoint);
+});
+
+test('Validate endpoint when configured with http protocol', () => {
+  const options = {
+    bucket: 'test',
+    region: 'region-test',
+    key: 'test-key',
+    secret: 'test-secret',
+    endpoint: 'http://' + domain
+  };
+  const config = new s3(options).getConfig().config;
+  const expectedEndpoint = {
+    host: domain,
+    hostname: domain,
+    href: 'http://' + domain + '/',
+    path: '/',
+    pathname: '/',
+    port: 80,
+    protocol: 'http:'
+  };
+  expect(config.endpoint).toEqual(expectedEndpoint);
+});
+
+test('Validate endpoint when configured with port', () => {
+  const options = {
+    bucket: 'test',
+    region: 'region-test',
+    key: 'test-key',
+    secret: 'test-secret',
+    endpoint: domain + ':1234'
+  };
+  const config = new s3(options).getConfig().config;
+  const expectedEndpoint = {
+    host: domain + ':1234',
+    hostname: domain,
+    href: 'https://' + domain + ':1234/',
+    path: '/',
+    pathname: '/',
+    port: 1234,
+    protocol: 'https:'
+  };
+  expect(config.endpoint).toEqual(expectedEndpoint);
+});

--- a/packages/oc-s3-storage-adapter/index.js
+++ b/packages/oc-s3-storage-adapter/index.js
@@ -55,12 +55,7 @@ module.exports = function(conf) {
 
   // Setup endpoint
   if (conf.endpoint) {
-    let endpoint = new AWS.Endpoint(conf.endpoint.hostname);
-    endpoint.port = conf.endpoint.port ? conf.endpoint.port : endpoint.port;
-    endpoint.protocol = conf.endpoint.protocol
-      ? conf.endpoint.protocol
-      : endpoint.protocol;
-    endpoint.path = conf.endpoint.path ? conf.endpoint.path : endpoint.path;
+    let endpoint = new AWS.Endpoint(conf.endpoint);
     awsConfig.update({
       endpoint
     });
@@ -79,6 +74,8 @@ module.exports = function(conf) {
   });
 
   const getClient = () => new AWS.S3(awsConfig);
+
+  const getConfig = () => getClient();
 
   const getFile = (filePath, force, callback) => {
     if (_.isFunction(force)) {
@@ -247,6 +244,7 @@ module.exports = function(conf) {
     putFile,
     putFileContent,
     adapterType: 's3',
-    isValid
+    isValid,
+    getConfig
   };
 };


### PR DESCRIPTION
Hi!

Instead of passing an object with different attributes, ie: 

```
{
  port: 8888,
  hostname: 'localhost',
  host: 'localhost:8888',
  protocol: 'http'
}
```

one can now just pass a string like `http://localhost:8080` or `localhost:8080` to achieve the same result. If the string used is missing the protocol then _https_ will be used as default. This solution falls back on aws-sdk to set the defaults instead of juggling around with the different endpoints options ourselves. Simplifies for the enduser and simplifies the code.

In order to be able to test the configuration of endpoints I added the method `getConfig`  to the _oc-s3-storage-adapter_. There is a new test file part of this PR for just testing the configuration of endpoint.