### PR TITLE
Verify server.js file name with both kind of slashes

### DIFF
--- a/packages/oc-azure-storage-adapter/__mocks__/azure-storage.js
+++ b/packages/oc-azure-storage-adapter/__mocks__/azure-storage.js
@@ -22,12 +22,14 @@ jest.mock('fs-extra', () => {
 jest.mock('node-dir', () => {
   return {
     paths: jest.fn((pathToDir, cb) => {
-      const sep = require('path').sep;
       cb(null, {
         files: [
-          `${pathToDir}${sep}package.json`,
-          `${pathToDir}${sep}server.js`,
-          `${pathToDir}${sep}template.js`
+          `${pathToDir}\\package.json`,
+          `${pathToDir}\\server.js`,
+          `${pathToDir}\\template.js`,
+          `${pathToDir}/package.json`,
+          `${pathToDir}/server.js`,
+          `${pathToDir}/template.js`
         ]
       });
     })

--- a/packages/oc-azure-storage-adapter/__test__/azure.test.js
+++ b/packages/oc-azure-storage-adapter/__test__/azure.test.js
@@ -191,9 +191,7 @@ test('test getJson force mode', done => {
   { path: 'components/image/', expected: ['1.0.0', '1.0.1'] },
   { path: 'components/image/1.0.0/', expected: [] }
 ].forEach(scenario => {
-  test(`test listObjects when bucket is not empty for folder ${
-    scenario.path
-  }`, done => {
+  test(`test listObjects when bucket is not empty for folder ${scenario.path}`, done => {
     const client = new azure({
       publicContainerName: 'pubcon',
       privateContainerName: 'privcon'

--- a/packages/oc-azure-storage-adapter/__test__/privateFilesExclusion.test.js
+++ b/packages/oc-azure-storage-adapter/__test__/privateFilesExclusion.test.js
@@ -1,0 +1,41 @@
+const adapter = require('../');
+
+jest.mock('async', () => {
+  return {
+    each: jest.fn((files, fileProcessing, cb) => {
+      const result = {};
+      let noProcessed = 0;
+      for (let file of files) {
+        fileProcessing(file, (err, res) => {
+          result[file] = { err, res };
+          noProcessed++;
+          if (noProcessed === files.length) cb(null, result);
+        });
+      }
+    })
+  };
+});
+
+test('put directory recognizes server.js to be private', done => {
+  const client = new adapter({
+    publicContainerName: 'pubcon',
+    privateContainerName: 'privcon'
+  });
+
+  client.putDir('.', '.', (_, mockResult) => {
+    const separators = ['\\', '/'];
+    for (let separator of separators) {
+      expect(mockResult[`.${separator}server.js`].res.container).toBe(
+        'privcon'
+      );
+      expect(mockResult[`.${separator}package.json`].res.container).toBe(
+        'pubcon'
+      );
+      expect(mockResult[`.${separator}template.js`].res.container).toBe(
+        'pubcon'
+      );
+    }
+
+    done();
+  });
+});

--- a/packages/oc-azure-storage-adapter/index.js
+++ b/packages/oc-azure-storage-adapter/index.js
@@ -200,7 +200,7 @@ module.exports = function(conf) {
             url = (dirOutput + relativeFile).replace(/\\/g, '/');
 
           const serverJsNames = ['/server.js', '\\server.js'];
-          putFile(file, url, serverJsNames.indexOf(relativeFile) !== -1, cb);
+          putFile(file, url, serverJsNames.includes(relativeFile), cb);
         },
         callback
       );

--- a/packages/oc-azure-storage-adapter/index.js
+++ b/packages/oc-azure-storage-adapter/index.js
@@ -199,7 +199,8 @@ module.exports = function(conf) {
           const relativeFile = file.substr(dirInput.length),
             url = (dirOutput + relativeFile).replace(/\\/g, '/');
 
-          putFile(file, url, relativeFile === '/server.js', cb);
+          const serverJsNames = ['/server.js', '\\server.js'];
+          putFile(file, url, serverJsNames.indexOf(relativeFile) !== -1, cb);
         },
         callback
       );

--- a/packages/oc-gs-storage-adapter/__test__/privateFilesExclusion.test.js
+++ b/packages/oc-gs-storage-adapter/__test__/privateFilesExclusion.test.js
@@ -1,0 +1,61 @@
+const gs = require('../');
+
+jest.mock('node-dir', () => {
+  return {
+    paths: jest.fn((pathToDir, cb) => {
+      cb(null, {
+        files: [
+          `${pathToDir}\\package.json`,
+          `${pathToDir}\\server.js`,
+          `${pathToDir}\\template.js`,
+          `${pathToDir}/package.json`,
+          `${pathToDir}/server.js`,
+          `${pathToDir}/template.js`
+        ]
+      });
+    })
+  };
+});
+
+jest.mock('async', () => {
+  return {
+    each: jest.fn((files, fileProcessing, cb) => {
+      const result = {};
+      let noProcessed = 0;
+      for (let file of files) {
+        fileProcessing(file, (err, res) => {
+          result[file] = { err, res };
+          noProcessed++;
+          if (noProcessed === files.length) cb(null, result);
+        });
+      }
+    })
+  };
+});
+
+test('put directory recognizes server.js to be private', done => {
+  const options = {
+    bucket: 'test',
+    projectId: '12345',
+    path: 'somepath'
+  };
+  const client = new gs(options);
+
+  client.putDir('.', '.', (_, mockResult) => {
+    console.log(mockResult);
+    const separators = ['\\', '/'];
+    for (let separator of separators) {
+      expect(mockResult[`.${separator}server.js`].res.ACL).toBe(
+        'authenticated-read'
+      );
+      expect(mockResult[`.${separator}package.json`].res.ACL).toBe(
+        'public-read'
+      );
+      expect(mockResult[`.${separator}template.js`].res.ACL).toBe(
+        'public-read'
+      );
+    }
+
+    done();
+  });
+});

--- a/packages/oc-gs-storage-adapter/__test__/privateFilesExclusion.test.js
+++ b/packages/oc-gs-storage-adapter/__test__/privateFilesExclusion.test.js
@@ -42,7 +42,6 @@ test('put directory recognizes server.js to be private', done => {
   const client = new gs(options);
 
   client.putDir('.', '.', (_, mockResult) => {
-    console.log(mockResult);
     const separators = ['\\', '/'];
     for (let separator of separators) {
       expect(mockResult[`.${separator}server.js`].res.ACL).toBe(

--- a/packages/oc-gs-storage-adapter/index.js
+++ b/packages/oc-gs-storage-adapter/index.js
@@ -147,7 +147,7 @@ module.exports = function(conf) {
           const relativeFile = file.substr(dirInput.length);
           const url = (dirOutput + relativeFile).replace(/\\/g, '/');
           const serverJsNames = ['/server.js', '\\server.js'];
-          putFile(file, url, serverJsNames.indexOf(relativeFile) !== -1, cb);
+          putFile(file, url, serverJsNames.includes(relativeFile), cb);
         },
         callback
       );

--- a/packages/oc-gs-storage-adapter/index.js
+++ b/packages/oc-gs-storage-adapter/index.js
@@ -146,7 +146,8 @@ module.exports = function(conf) {
         (file, cb) => {
           const relativeFile = file.substr(dirInput.length);
           const url = (dirOutput + relativeFile).replace(/\\/g, '/');
-          putFile(file, url, relativeFile === '/server.js', cb);
+          const serverJsNames = ['/server.js', '\\server.js'];
+          putFile(file, url, serverJsNames.indexOf(relativeFile) !== -1, cb);
         },
         callback
       );

--- a/packages/oc-s3-storage-adapter/__mocks__/aws-sdk.js
+++ b/packages/oc-s3-storage-adapter/__mocks__/aws-sdk.js
@@ -11,12 +11,14 @@ jest.mock('fs-extra', () => {
 jest.mock('node-dir', () => {
   return {
     paths: jest.fn((pathToDir, cb) => {
-      const sep = require('path').sep;
       cb(null, {
         files: [
-          `${pathToDir}${sep}package.json`,
-          `${pathToDir}${sep}server.js`,
-          `${pathToDir}${sep}template.js`
+          `${pathToDir}\\package.json`,
+          `${pathToDir}\\server.js`,
+          `${pathToDir}\\template.js`,
+          `${pathToDir}/package.json`,
+          `${pathToDir}/server.js`,
+          `${pathToDir}/template.js`
         ]
       });
     })

--- a/packages/oc-s3-storage-adapter/__test__/privateFilesExclusion.test.js
+++ b/packages/oc-s3-storage-adapter/__test__/privateFilesExclusion.test.js
@@ -1,0 +1,45 @@
+const s3 = require('../');
+
+jest.mock('async', () => {
+  return {
+    each: jest.fn((files, fileProcessing, cb) => {
+      const result = {};
+      let noProcessed = 0;
+      for (let file of files) {
+        fileProcessing(file, (err, res) => {
+          result[file] = { err, res };
+          noProcessed++;
+          if (noProcessed === files.length) cb(null, result);
+        });
+      }
+    })
+  };
+});
+
+test('put directory recognizes server.js to be private', done => {
+  const options = {
+    bucket: 'test',
+    region: 'region-test',
+    key: 'test-key',
+    secret: 'test-secret'
+  };
+
+  const client = new s3(options);
+
+  client.putDir('.', '.', (_, mockResult) => {
+    const separators = ['\\', '/'];
+    for (let separator of separators) {
+      expect(mockResult[`.${separator}server.js`].res.ACL).toBe(
+        'authenticated-read'
+      );
+      expect(mockResult[`.${separator}package.json`].res.ACL).toBe(
+        'public-read'
+      );
+      expect(mockResult[`.${separator}template.js`].res.ACL).toBe(
+        'public-read'
+      );
+    }
+
+    done();
+  });
+});

--- a/packages/oc-s3-storage-adapter/index.js
+++ b/packages/oc-s3-storage-adapter/index.js
@@ -196,7 +196,7 @@ module.exports = function(conf) {
             url = (dirOutput + relativeFile).replace(/\\/g, '/');
 
           const serverJsNames = ['/server.js', '\\server.js'];
-          putFile(file, url, serverJsNames.indexOf(relativeFile) !== -1, cb);
+          putFile(file, url, serverJsNames.includes(relativeFile), cb);
         },
         callback
       );

--- a/packages/oc-s3-storage-adapter/index.js
+++ b/packages/oc-s3-storage-adapter/index.js
@@ -195,7 +195,8 @@ module.exports = function(conf) {
           const relativeFile = file.substr(dirInput.length),
             url = (dirOutput + relativeFile).replace(/\\/g, '/');
 
-          putFile(file, url, relativeFile === '/server.js', cb);
+          const serverJsNames = ['/server.js', '\\server.js'];
+          putFile(file, url, serverJsNames.indexOf(relativeFile) !== -1, cb);
         },
         callback
       );


### PR DESCRIPTION
Fixes #239 

This is internal implementation of `putDir`, if anyone has any suggestions on how to mock it out and test it I can update this PR or make a follow up with updated tests.