### PR TITLE
Set cache control header on blob storage

### DIFF
--- a/packages/oc-azure-storage-adapter/__mocks__/azure-storage.js
+++ b/packages/oc-azure-storage-adapter/__mocks__/azure-storage.js
@@ -88,13 +88,18 @@ const blobService = {
     ].filter(entry => entry.name.startsWith(prefix));
     return callback(null, { entries: entriesToReturn });
   },
-  createWriteStreamToBlockBlob: (containerName, fileName, _, callback) => {
+  createWriteStreamToBlockBlob: (
+    containerName,
+    fileName,
+    settings,
+    callback
+  ) => {
     let lengthWritten = 0;
     const writeStream = new LengthCallbackStream(
       length => (lengthWritten += length)
     );
     writeStream.on('finish', () =>
-      callback(null, { lengthWritten, container: containerName })
+      callback(null, { lengthWritten, container: containerName, settings })
     );
     return writeStream;
   },

--- a/packages/oc-azure-storage-adapter/__test__/azure.test.js
+++ b/packages/oc-azure-storage-adapter/__test__/azure.test.js
@@ -290,6 +290,9 @@ test('test private putFileContent stream', done => {
     expect(err).toBe(null);
     expect(result.container).toBe('privcon');
     expect(result.lengthWritten).toBe(fileContent.length);
+    expect(result.settings.contentSettings.cacheControl).toBe(
+      'public, max-age=31556926'
+    );
     done();
   });
 });

--- a/packages/oc-azure-storage-adapter/index.js
+++ b/packages/oc-azure-storage-adapter/index.js
@@ -209,7 +209,9 @@ module.exports = function(conf) {
 
   const putFileContent = (fileContent, fileName, isPrivate, callback) => {
     const fileInfo = getFileInfo(fileName);
-    const contentSettings = {};
+    const contentSettings = {
+      cacheControl: 'public, max-age=31556926'
+    };
     if (fileInfo.mimeType) {
       contentSettings.contentType = fileInfo.mimeType;
     }


### PR DESCRIPTION
Current implementation of blob storage adapter doesn't set cache-control setting on uploaded blobs. As OC components are immutable (once published version never changes) we can actually tell the browser to cache files like template.js forever which will greatly improve perceived performance.

This PR makes the adapter set correct headers.