### PR TITLE
[IMPROVEMENT] Add .env as a private file for storage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "parser": "@typescript-eslint/parser",
   "env": {
     "es6": true,
-    "node": true
+    "node": true,
+    "jest": true
   },
   "extends": [
     "eslint:recommended",

--- a/packages/oc-azure-storage-adapter/__mocks__/azure-storage.js
+++ b/packages/oc-azure-storage-adapter/__mocks__/azure-storage.js
@@ -26,9 +26,11 @@ jest.mock('node-dir', () => {
         files: [
           `${pathToDir}\\package.json`,
           `${pathToDir}\\server.js`,
+          `${pathToDir}\\.env`,
           `${pathToDir}\\template.js`,
           `${pathToDir}/package.json`,
           `${pathToDir}/server.js`,
+          `${pathToDir}/.env`,
           `${pathToDir}/template.js`
         ]
       });

--- a/packages/oc-azure-storage-adapter/__test__/privateFilesExclusion.test.js
+++ b/packages/oc-azure-storage-adapter/__test__/privateFilesExclusion.test.js
@@ -16,7 +16,7 @@ jest.mock('async', () => {
   };
 });
 
-test('put directory recognizes server.js to be private', done => {
+test('put directory recognizes server.js and .env to be private', done => {
   const client = new adapter({
     publicContainerName: 'pubcon',
     privateContainerName: 'privcon'
@@ -28,6 +28,7 @@ test('put directory recognizes server.js to be private', done => {
       expect(mockResult[`.${separator}server.js`].res.container).toBe(
         'privcon'
       );
+      expect(mockResult[`.${separator}.env`].res.container).toBe('privcon');
       expect(mockResult[`.${separator}package.json`].res.container).toBe(
         'pubcon'
       );

--- a/packages/oc-azure-storage-adapter/index.js
+++ b/packages/oc-azure-storage-adapter/index.js
@@ -196,8 +196,13 @@ module.exports = function (conf) {
           const relativeFile = file.substr(dirInput.length),
             url = (dirOutput + relativeFile).replace(/\\/g, '/');
 
-          const serverJsNames = ['/server.js', '\\server.js'];
-          putFile(file, url, serverJsNames.includes(relativeFile), cb);
+          const privateFileNames = [
+            '/server.js',
+            '\\server.js',
+            '/.env',
+            '\\.env'
+          ];
+          putFile(file, url, privateFileNames.includes(relativeFile), cb);
         },
         callback
       );

--- a/packages/oc-azure-storage-adapter/index.js
+++ b/packages/oc-azure-storage-adapter/index.js
@@ -196,13 +196,15 @@ module.exports = function (conf) {
           const relativeFile = file.substr(dirInput.length),
             url = (dirOutput + relativeFile).replace(/\\/g, '/');
 
-          const privateFileNames = [
-            '/server.js',
-            '\\server.js',
-            '/.env',
-            '\\.env'
-          ];
-          putFile(file, url, privateFileNames.includes(relativeFile), cb);
+          const serverPattern = /(\\|\/)server\.js/;
+          const dotFilePattern = /(\\|\/)\..+/;
+          const privateFilePatterns = [serverPattern, dotFilePattern];
+          putFile(
+            file,
+            url,
+            privateFilePatterns.some(r => r.test(relativeFile)),
+            cb
+          );
         },
         callback
       );

--- a/packages/oc-gs-storage-adapter/__mocks__/@google-cloud/storage.js
+++ b/packages/oc-gs-storage-adapter/__mocks__/@google-cloud/storage.js
@@ -13,6 +13,7 @@ jest.mock('node-dir', () => {
         files: [
           `${pathToDir}${sep}package.json`,
           `${pathToDir}${sep}server.js`,
+          `${pathToDir}${sep}.env`,
           `${pathToDir}${sep}template.js`
         ]
       });
@@ -40,7 +41,13 @@ const _Storage = class {
                     name: 'components/image/1.0.0/server.js'
                   },
                   {
+                    name: 'components/image/1.0.0/.env'
+                  },
+                  {
                     name: 'components/image/1.0.1/new-server.js'
+                  },
+                  {
+                    name: 'components/image/1.0.1/new-.env'
                   },
                   {
                     name: 'components/image/1.0.1/new-app.js'

--- a/packages/oc-gs-storage-adapter/__test__/privateFilesExclusion.test.js
+++ b/packages/oc-gs-storage-adapter/__test__/privateFilesExclusion.test.js
@@ -7,9 +7,11 @@ jest.mock('node-dir', () => {
         files: [
           `${pathToDir}\\package.json`,
           `${pathToDir}\\server.js`,
+          `${pathToDir}\\.env`,
           `${pathToDir}\\template.js`,
           `${pathToDir}/package.json`,
           `${pathToDir}/server.js`,
+          `${pathToDir}/.env`,
           `${pathToDir}/template.js`
         ]
       });
@@ -33,7 +35,7 @@ jest.mock('async', () => {
   };
 });
 
-test('put directory recognizes server.js to be private', done => {
+test('put directory recognizes server.js and .env to be private', done => {
   const options = {
     bucket: 'test',
     projectId: '12345',
@@ -45,6 +47,9 @@ test('put directory recognizes server.js to be private', done => {
     const separators = ['\\', '/'];
     for (let separator of separators) {
       expect(mockResult[`.${separator}server.js`].res.ACL).toBe(
+        'authenticated-read'
+      );
+      expect(mockResult[`.${separator}.env`].res.ACL).toBe(
         'authenticated-read'
       );
       expect(mockResult[`.${separator}package.json`].res.ACL).toBe(

--- a/packages/oc-gs-storage-adapter/index.js
+++ b/packages/oc-gs-storage-adapter/index.js
@@ -156,8 +156,13 @@ module.exports = function (conf) {
         (file, cb) => {
           const relativeFile = file.substr(dirInput.length);
           const url = (dirOutput + relativeFile).replace(/\\/g, '/');
-          const serverJsNames = ['/server.js', '\\server.js'];
-          putFile(file, url, serverJsNames.includes(relativeFile), cb);
+          const privateFileNames = [
+            '/server.js',
+            '\\server.js',
+            '/.env',
+            '\\.env'
+          ];
+          putFile(file, url, privateFileNames.includes(relativeFile), cb);
         },
         callback
       );

--- a/packages/oc-gs-storage-adapter/index.js
+++ b/packages/oc-gs-storage-adapter/index.js
@@ -156,13 +156,15 @@ module.exports = function (conf) {
         (file, cb) => {
           const relativeFile = file.substr(dirInput.length);
           const url = (dirOutput + relativeFile).replace(/\\/g, '/');
-          const privateFileNames = [
-            '/server.js',
-            '\\server.js',
-            '/.env',
-            '\\.env'
-          ];
-          putFile(file, url, privateFileNames.includes(relativeFile), cb);
+          const serverPattern = /(\\|\/)server\.js/;
+          const dotFilePattern = /(\\|\/)\..+/;
+          const privateFilePatterns = [serverPattern, dotFilePattern];
+          putFile(
+            file,
+            url,
+            privateFilePatterns.some(r => r.test(relativeFile)),
+            cb
+          );
         },
         callback
       );

--- a/packages/oc-s3-storage-adapter/__mocks__/aws-sdk.js
+++ b/packages/oc-s3-storage-adapter/__mocks__/aws-sdk.js
@@ -15,9 +15,11 @@ jest.mock('node-dir', () => {
         files: [
           `${pathToDir}\\package.json`,
           `${pathToDir}\\server.js`,
+          `${pathToDir}\\.env`,
           `${pathToDir}\\template.js`,
           `${pathToDir}/package.json`,
           `${pathToDir}/server.js`,
+          `${pathToDir}/.env`,
           `${pathToDir}/template.js`
         ]
       });

--- a/packages/oc-s3-storage-adapter/__test__/privateFilesExclusion.test.js
+++ b/packages/oc-s3-storage-adapter/__test__/privateFilesExclusion.test.js
@@ -16,7 +16,7 @@ jest.mock('async', () => {
   };
 });
 
-test('put directory recognizes server.js to be private', done => {
+test('put directory recognizes server.js and .env to be private', done => {
   const options = {
     bucket: 'test',
     region: 'region-test',
@@ -29,6 +29,9 @@ test('put directory recognizes server.js to be private', done => {
   client.putDir('.', '.', (_, mockResult) => {
     const separators = ['\\', '/'];
     for (let separator of separators) {
+      expect(mockResult[`.${separator}.env`].res.ACL).toBe(
+        'authenticated-read'
+      );
       expect(mockResult[`.${separator}server.js`].res.ACL).toBe(
         'authenticated-read'
       );

--- a/packages/oc-s3-storage-adapter/index.js
+++ b/packages/oc-s3-storage-adapter/index.js
@@ -196,8 +196,13 @@ module.exports = function (conf) {
           const relativeFile = file.substr(dirInput.length),
             url = (dirOutput + relativeFile).replace(/\\/g, '/');
 
-          const serverJsNames = ['/server.js', '\\server.js'];
-          putFile(file, url, serverJsNames.includes(relativeFile), cb);
+          const privateFileNames = [
+            '/server.js',
+            '\\server.js',
+            '/.env',
+            '\\.env'
+          ];
+          putFile(file, url, privateFileNames.includes(relativeFile), cb);
         },
         callback
       );

--- a/packages/oc-s3-storage-adapter/index.js
+++ b/packages/oc-s3-storage-adapter/index.js
@@ -196,13 +196,15 @@ module.exports = function (conf) {
           const relativeFile = file.substr(dirInput.length),
             url = (dirOutput + relativeFile).replace(/\\/g, '/');
 
-          const privateFileNames = [
-            '/server.js',
-            '\\server.js',
-            '/.env',
-            '\\.env'
-          ];
-          putFile(file, url, privateFileNames.includes(relativeFile), cb);
+          const serverPattern = /(\\|\/)server\.js/;
+          const dotFilePattern = /(\\|\/)\..+/;
+          const privateFilePatterns = [serverPattern, dotFilePattern];
+          putFile(
+            file,
+            url,
+            privateFilePatterns.some(r => r.test(relativeFile)),
+            cb
+          );
         },
         callback
       );


### PR DESCRIPTION
Related to this [issue](https://github.com/opencomponents/oc/issues/1193), this is the first step so that `.env` files with secrets can be uploaded to storage, so they can be retreived on the server side and used as part of the context for the server side.