### PR TITLE
fixed oc-s3-storage-adapter to use IAM roles 

### DIFF
--- a/packages/oc-s3-storage-adapter/__test__/s3.test.ts
+++ b/packages/oc-s3-storage-adapter/__test__/s3.test.ts
@@ -14,7 +14,8 @@ const validOptions = {
   region: 'region-test',
   key: 'test-key',
   secret: 'test-secret',
-  path: '/'
+  path: '/',
+  componentsDir: 'components'
 };
 
 test('should expose the correct methods', () => {

--- a/packages/oc-s3-storage-adapter/src/index.ts
+++ b/packages/oc-s3-storage-adapter/src/index.ts
@@ -1,4 +1,4 @@
-import { S3 } from '@aws-sdk/client-s3';
+import { S3, S3ClientConfig } from '@aws-sdk/client-s3';
 import {
   NodeHttpHandler,
   NodeHttpHandlerOptions
@@ -95,19 +95,23 @@ export default function s3Adapter(conf: S3Config): StorageAdapter {
     requestHandler = new NodeHttpHandler(handlerOptions);
   }
 
-  const getClient = () =>
-    new S3({
+  const getClient = () => {
+    const configOpts: S3ClientConfig = {
       logger: conf.debug ? (console.log as any) : undefined,
       tls: sslEnabled,
-      credentials: {
-        accessKeyId: accessKeyId!,
-        secretAccessKey: secretAccessKey!
-      },
       requestHandler,
       endpoint: conf.endpoint,
       region,
       forcePathStyle: s3ForcePathStyle
-    });
+    }
+    if (accessKeyId && secretAccessKey) {
+      configOpts.credentials = {
+        accessKeyId,
+        secretAccessKey
+      };
+    }
+    return new S3(configOpts);
+  };
 
   const getFile = async (filePath: string, force = false) => {
     const getFromAws = async () => {


### PR DESCRIPTION
Fixes [#1322](https://github.com/opencomponents/oc/issues/1322)

**Bug:**
We are not able to use `IAM roles` when using `oc-s3-storage-adapter`.

**Issue:**
For the `@aws-sdk/client-s3` to use IAM roles, we have to not send credentials config while initializing S3 object.

**Fix:**
Not send credentials object while initializing S3 object if there is no accessKey or secretKey provided
