### PR TITLE
creating a single client to put folders in cloud

### DIFF
--- a/packages/oc-azure-storage-adapter/__test__/azure.test.ts
+++ b/packages/oc-azure-storage-adapter/__test__/azure.test.ts
@@ -15,7 +15,8 @@ const validOptions = {
   privateContainerName: 'privcon',
   accountName: 'name',
   accountKey: 'key',
-  path: '/'
+  path: '/',
+  componentsDir: 'components'
 };
 
 test('should expose the correct methods', () => {

--- a/packages/oc-azure-storage-adapter/__test__/privateFilesExclusion.test.ts
+++ b/packages/oc-azure-storage-adapter/__test__/privateFilesExclusion.test.ts
@@ -7,7 +7,8 @@ test('put directory recognizes server.js and .env to be private', async () => {
     privateContainerName: 'privcon',
     accountName: 'name',
     accountKey: 'key',
-    path: '/'
+    path: '/',
+    componentsDir: 'components'
   });
 
   const mockResult = (await client.putDir('.', '.')) as Array<{

--- a/packages/oc-gs-storage-adapter/__test__/gs.test.ts
+++ b/packages/oc-gs-storage-adapter/__test__/gs.test.ts
@@ -28,7 +28,8 @@ global.Date.now = _Date.now;
 const validOptions = {
   bucket: 'test',
   projectId: '12345',
-  path: '/'
+  path: '/',
+  componentsDir: 'components'
 };
 
 test('should expose the correct methods', () => {

--- a/packages/oc-gs-storage-adapter/__test__/privateFilesExclusion.test.ts
+++ b/packages/oc-gs-storage-adapter/__test__/privateFilesExclusion.test.ts
@@ -24,7 +24,8 @@ test('put directory recognizes server.js and .env to be private', async () => {
   const options = {
     bucket: 'test',
     projectId: '12345',
-    path: 'somepath'
+    path: 'somepath',
+    componentsDir: 'components'
   };
   const client = gs(options);
 

--- a/packages/oc-riak-storage-adapter/__test__/s3.test.ts
+++ b/packages/oc-riak-storage-adapter/__test__/s3.test.ts
@@ -14,7 +14,8 @@ const validOptions = {
   region: 'region-test',
   key: 'test-key',
   secret: 'test-secret',
-  path: '/'
+  path: '/',
+  componentsDir: 'components'
 };
 
 test('should expose the correct methods', () => {

--- a/packages/oc-s3-storage-adapter/__test__/privateFilesExclusion.test.ts
+++ b/packages/oc-s3-storage-adapter/__test__/privateFilesExclusion.test.ts
@@ -7,7 +7,8 @@ test('put directory recognizes server.js and .env to be private', async () => {
     region: 'region-test',
     key: 'test-key',
     secret: 'test-secret',
-    path: '/'
+    path: '/',
+    componentsDir: 'components'
   };
 
   const client = s3(options);

--- a/packages/oc-storage-adapters-utils/src/index.ts
+++ b/packages/oc-storage-adapters-utils/src/index.ts
@@ -21,12 +21,14 @@ export interface StorageAdapter {
   putFile(
     filePath: string,
     fileName: string,
-    isPrivate: boolean
+    isPrivate: boolean,
+    client?: unknown
   ): Promise<unknown>;
   putFileContent(
     data: unknown,
     path: string,
-    isPrivate: boolean
+    isPrivate: boolean,
+    client?: unknown
   ): Promise<unknown>;
   isValid: () => boolean;
 }


### PR DESCRIPTION

Relates to [#1325](https://github.com/opencomponents/oc/issues/1325)

Explain the details for making this change. What existing problem does the pull request solve?
- With large number of files in a folder and uploading them, s3 storage adapter was creating new client for each file and this failed as there were limits to get new s3 client.
- Fix was to create a single client while `putDir` operation was called and use the same client to upload files


`closes #1325`