### PR TITLE
Fix errors on initializing a new registry connected to an Amazon S3 bucket

### DIFF
--- a/packages/oc-s3-storage-adapter/package.json
+++ b/packages/oc-s3-storage-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-s3-storage-adapter",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "S3 storage adapter for OC",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/oc-s3-storage-adapter/package.json
+++ b/packages/oc-s3-storage-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-s3-storage-adapter",
-  "version": "2.1.2",
+  "version": "2.1.1",
   "description": "S3 storage adapter for OC",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/oc-s3-storage-adapter/src/index.ts
+++ b/packages/oc-s3-storage-adapter/src/index.ts
@@ -123,7 +123,7 @@ export default function s3Adapter(conf: S3Config): StorageAdapter {
 
         return streamToString(data.Body as any);
       } catch (err) {
-        throw (err as any).code === 'NoSuchKey'
+        throw (err as any).Code === 'NoSuchKey'
           ? {
               code: strings.errors.STORAGE.FILE_NOT_FOUND_CODE,
               msg: strings.errors.STORAGE.FILE_NOT_FOUND(filePath)
@@ -176,7 +176,7 @@ export default function s3Adapter(conf: S3Config): StorageAdapter {
       Delimiter: '/'
     });
 
-    if (data.CommonPrefixes!.length === 0) {
+    if (data.CommonPrefixes === undefined || data.CommonPrefixes.length === 0) {
       throw {
         code: strings.errors.STORAGE.DIR_NOT_FOUND_CODE,
         msg: strings.errors.STORAGE.DIR_NOT_FOUND(dir)


### PR DESCRIPTION
Without this patch a new registry can not be created on Amazon S3 buckets (this patch fixes errors after migration to AWS S3 API v3)